### PR TITLE
Markifnotmaster: New functionality to watermark if not working on release/publish/master-branch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 \#*
 auto/
 */.auxfiles/
+sandbox/
 build/
 gitHeadInfo.gin
 tugboat/tugboat.bib

--- a/.gitlab-ci.yml.example
+++ b/.gitlab-ci.yml.example
@@ -1,0 +1,6 @@
+compile_pdf:
+  script:
+    - latexmk -cd -e -f -pdf -view=none "main.tex"
+  artifacts:
+    paths:
+      - main.pdf

--- a/.latexmkrc.example
+++ b/.latexmkrc.example
@@ -1,0 +1,2 @@
+# gitinfo2
+system("gitinfo2 -c CI_BUILD_REF_NAME");

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,15 @@ git = git
 silent =
 include ~/.make/Makefile
 
-archive = gitinfo2.tar.gz
+pkg = gitinfo2
+archive = $(pkg).tar.gz
 ginfile = .git/gitHeadInfo.gin
 pseudofile = gitHeadLocal.gin
 
-codelist = gitinfo2.sty gitexinfo.sty
-docslist = gitinfo2.tex gitinfo2.pdf $(pseudofile)
+codelist = $(pkg).sty gitexinfo.sty
+docslist = $(pkg).tex $(pkg).pdf $(pseudofile)
 morelist = gitinfotest.tex post-xxx-sample.txt README
-dirtlist = gitinfo2.pdf gitinfo2.tar.gz $(pseudofile)
+dirtlist = $(pkg).pdf $(pkg).tar.gz $(pseudofile)
 
 list = $(codelist) $(docslist) $(morelist)
 
@@ -34,7 +35,7 @@ $(archive): $(list)
 clean $(ginfile):
 	$(git) checkout $(dirtlist)
 
-gitinfo2.pdf: gitinfo2.tex $(pseudofile)
+$(pkg).pdf: $(pkg).tex $(codelist) $(pseudofile)
 	rm -f $@ $(auxdir)/$@
 	$(lmkexec) -outdir=$(auxdir) $(silent) -xelatex -e '$$makeindex=q/makeindex %O -s blindex.ist -o %D %S/' "$<"
 	chmod a+rw $(auxdir) $(auxdir)/*

--- a/gitexinfo.sty
+++ b/gitexinfo.sty
@@ -32,6 +32,7 @@
 \DeclareStringOption{commsdate}
 \DeclareStringOption{commidate}
 \DeclareStringOption{commudate}
+\DeclareStringOption{currbranch}
 \DeclareStringOption{refnames}
 \DeclareStringOption{firsttagdescribe}
 \DeclareStringOption{reltag}
@@ -48,6 +49,7 @@
 \renewcommand{\gitCommitterDate}{\gitInf@commsdate}
 \renewcommand{\gitCommitterIsoDate}{\gitInf@commidate}
 \renewcommand{\gitCommitterUnixDate}{\gitInf@commudate}
+\renewcommand{\gitCurrBranch}{\gitInf@currbranch}
 \renewcommand{\gitFirstTagDescribe}{\detokenize\expandafter{\gitInf@firsttagdescribe}}
 \renewcommand{\gitReferences}{\detokenize\expandafter{\gitInf@refnames}}
 \newcommand{\git@vtag}[1]{%

--- a/gitexinfo.sty
+++ b/gitexinfo.sty
@@ -69,9 +69,9 @@
             }{}%
         }%
     }%
-    \expandafter\docsvlist\expandafter{#1}%
     \StrDel{#1}{(}[\bcut]%
     \StrDel{\bcut}{)}[\bcut]%
+    \expandafter\docsvlist\expandafter{\bcut}%
     \IfSubStr{\bcut}{->}{%              git version 2+?
         \StrBetween{\bcut,}{HEAD -> }{,}[\bcut]%  yes - no problem
     }{%
@@ -81,7 +81,8 @@
             \StrCut[\xcut]{\bcut}{, }{\lcut}{\bcut}%  git vv < 2 - take last token
         }%                                            (not always accurate)
     }
-    \IfEq{\bcut}{}{}{%
+    \IfEq{\bcut}{}{%
+    }{%
         \IfEq{\bcut}{HEAD}{%            detached head?
         }{%                             no - we have the branch name
             \renewcommand{\gitBranch}{\detokenize\expandafter{\bcut}}%
@@ -112,7 +113,7 @@
         \StrCut[\gitInf@mcount]{\gitInf@describe}{-}{\gitInf@rel}{\gitInf@off}
         \renewcommand{\gitRel}{\detokenize\expandafter{\gitInf@rel}}
         \renewcommand{\gitRels}{\space\gitRel}
-        \renewcommand{\gitReln}{\space\gitRel}
+        \IfEq{\gitRel}{}{}{\renewcommand{\gitReln}{\space\gitRel}}
         \renewcommand{\gitRoff}{\gitInf@off}
         \renewcommand{\gitDescribe}{#1}
     }%

--- a/gitinfo2.sty
+++ b/gitinfo2.sty
@@ -102,6 +102,9 @@
   \GI@is@a@repo@true
   \IfFileExists{./\GI@githeadinfo@file}{%
     \edef\GI@repo@prefix{./}%
+      \PackageInfo{gitinfo2}{%
+      gitinfo2 found  : \GI@githeadinfo@file \MessageBreak
+      }%
     }{%
     \GI@set@repo@prefix}}
 
@@ -117,9 +120,9 @@
   \else
     \edef\GI@repo@prefix{../\GI@repo@prefix}%
     \IfFileExists{\GI@githeadinfo@file}{%
-  \PackageInfo{gitinfo2}{%
-  gitinfo2 found  : \GI@githeadinfo@file \MessageBreak
-  }%
+      \PackageInfo{gitinfo2}{%
+      gitinfo2 found  : \GI@githeadinfo@file \MessageBreak
+      }%
       \GI@export@macro\GI@githeadinfo@file
       }{%
       \expandafter\GI@set@repo@prefix@}%

--- a/gitinfo2.sty
+++ b/gitinfo2.sty
@@ -32,12 +32,14 @@
 \DeclareBoolOption{mark}
 \DeclareBoolOption{markifdraft}
 \DeclareBoolOption{markifdirty}
+\DeclareBoolOption{markifnotmaster}
 \DeclareBoolOption{marknotags}
 \DeclareStringOption[(None)]{missing}
 \DeclareStringOption[(None)]{notags}
 \DeclareStringOption[(*)]{dirty}
 \DeclareStringOption[4]{maxdepth}
 \DeclareStringOption[1.5\baselineskip]{raisemark}
+\DeclareStringOption[master]{master}
 \ProcessKeyvalOptions*
 \newcommand{\gitAbbrevHash}{\gitInf@missing}
 \newcommand{\gitHash}{\gitInf@missing}
@@ -55,6 +57,7 @@
 \newcommand{\gitFirstTagDescribe}{\gitInf@missing}
 \newcommand{\gitReferences}{\gitInf@missing}
 \newcommand{\gitBranch}{\gitInf@missing}
+\newcommand{\gitCurrBranch}{\gitInf@missing}
 \newcommand{\gitVtag}{}
 \newcommand{\gitVtags}{}
 \newcommand{\gitVtagn}{\space\gitInf@missing}
@@ -172,6 +175,11 @@
 % ---------------------------------------------------------------------
 % Watermarking
 % - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+\ifbool{gitInf@markifnotmaster}{%
+	\IfStrEq{\gitCurrBranch}{\gitInf@master}{}{%
+		\booltrue{gitInf@mark}
+	}%
+}{}%
 \ifbool{gitInf@markifdirty}{%
     \IfEq{\gitDirty}{}{}{%
         \booltrue{gitInf@mark}

--- a/post-xxx-sample.txt
+++ b/post-xxx-sample.txt
@@ -6,12 +6,31 @@
 # -----------------------------------------------------
 # Post-{commit,checkout,merge} hook for the gitinfo2 package
 #
+while getopts ":c:" opt; do
+        case $opt in
+        c)
+                if [ "$OPTARG" == "CI_BUILD_REF_NAME" ]; then
+                        CURRBRANCH=$CI_BUILD_REF_NAME
+                else
+                        CURRBRANCH=$OPTARG
+                fi
+                ;;
+        \?)
+                echo "unknown option: -$OPTARG"
+                exit 1
+                ;;
+        :)
+                echo "Option -$OPTARG requires an argument (name of current branch)."
+                exit 1
+                ;;
+        esac
+done
 # Get the first tag found in the history from the current HEAD
 FIRSTTAG=$(git describe --tags --always --dirty='-*' 2>/dev/null)
 # Get the first tag in history that looks like a Release
 RELTAG=$(git describe --tags --long --always --dirty='-*' --match '[0-9]*.*' 2>/dev/null)
 # Get the checked out branch
-CURRBRANCH=$( git rev-parse --abbrev-ref HEAD )
+CURRBRANCH="${CURRBRANCH:-$( git rev-parse --abbrev-ref HEAD )}"
 # Hoover up the metadata
 git --no-pager log -1 --date=short --decorate=short \
     --pretty=format:"\usepackage[%

--- a/post-xxx-sample.txt
+++ b/post-xxx-sample.txt
@@ -10,6 +10,8 @@
 FIRSTTAG=$(git describe --tags --always --dirty='-*' 2>/dev/null)
 # Get the first tag in history that looks like a Release
 RELTAG=$(git describe --tags --long --always --dirty='-*' --match '[0-9]*.*' 2>/dev/null)
+# Get the checked out branch
+CURRBRANCH=$( git rev-parse --abbrev-ref HEAD )
 # Hoover up the metadata
 git --no-pager log -1 --date=short --decorate=short \
     --pretty=format:"\usepackage[%
@@ -27,5 +29,6 @@ git --no-pager log -1 --date=short --decorate=short \
         commudate={%ct},
         refnames={%d},
         firsttagdescribe={$FIRSTTAG},
-        reltag={$RELTAG}
+        reltag={$RELTAG},
+        currbranch={$CURRBRANCH}
     ]{gitexinfo}" HEAD > .git/gitHeadInfo.gin


### PR DESCRIPTION
New package options:
- markifnotmaster: bool to enable watermarking if not on release-branch
- master: string (default: master); name of the release-branch

Example:
\usepackage[markifnotmaster,master=publish]{gitinfo2}
