### PR TITLE
added variable to get the full path of the .git directory

### DIFF
--- a/post-xxx-sample.txt
+++ b/post-xxx-sample.txt
@@ -10,6 +10,8 @@
 FIRSTTAG=$(git describe --tags --always --dirty='-*' 2>/dev/null)
 # Get the first tag in history that looks like a Release
 RELTAG=$(git describe --tags --long --always --dirty='-*' --match '[0-9]*.*' 2>/dev/null)
+# Get the path where gitHeadInfo.gin shall be put
+GINDIR=$(git rev-parse --git-dir 2>/dev/null)
 # Hoover up the metadata
 git --no-pager log -1 --date=short --decorate=short \
     --pretty=format:"\usepackage[%
@@ -28,4 +30,4 @@ git --no-pager log -1 --date=short --decorate=short \
         refnames={%d},
         firsttagdescribe={$FIRSTTAG},
         reltag={$RELTAG}
-    ]{gitexinfo}" HEAD > .git/gitHeadInfo.gin
+    ]{gitexinfo}" HEAD > $GINDIR/gitHeadInfo.gin


### PR DESCRIPTION
I've added an additional `GINDIR` variable so that the script knows where the `.git` folder is if it is called not from the root folder of the project.

This solves the problem I've encountered while using `gitinfo2` together with `git-subrepo`, as documented here: https://github.com/ingydotnet/git-subrepo/issues/499